### PR TITLE
[#1] Allow everyone to move server regions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# http://editorconfig.org
+root = true
+
+[*.{js,md}]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+charset = utf-8
+insert_final_newline = true
+
+[*.js]
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-node_modules 
+node_modules
 config.js

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ You have two choices:
 - Navigate to the folder and run `npm install`: `cd discord-server-change && npm install`
 - Copy the file `config.sample.js` to `config.js`.
 - Open **`config.js`** with a _text editor_ and add your [Discord bot token](https://www.writebots.com/discord-bot-token/)
+    - The configuration option `Discord.allowEveryoneToMoveRegion` can be used to decide if **everyone in the server** (regardless of permissions) can move server regions.
+    - I recommend leaving `Discord.allowEveryoneToMoveRegion` to `false` if you're hosting it on a public server, but it's useful for private servers with just friends.
 - Run the bot using `node index.js`.
     - If it runs successfully then I recommend setting it up as a service using [PM2 (process manager)][PM2-QS].
 - [Generate an invite URL][Discord-Invite] to add it to your server.
@@ -33,11 +35,15 @@ You have two choices:
 
 ## Usage
 
-The following server members can use the command(s):
+If the configuration option `Discord.allowEveryoneToMoveRegion` is set to `false` (default), then the following server members can use the commands:
 
 - Any server member with `Manage Server` (`MANAGE_GUILD`) permission.
 - Any server member with `Administrator` permission.
 - The server owner.
+
+If the configuration option `Discord.allowEveryoneToMoveRegion` is set to `true`, then **everyone** can use the commands - regardless of server permissions.
+
+For public servers, I recommend leaving `Discord.allowEveryoneToMoveRegion` to `false`.
 
 Keep in mind that commands will only work inside a text channel on the server.  
 Sending the bot a _direct message_ will **not** work.
@@ -53,6 +59,12 @@ Sending the bot a _direct message_ will **not** work.
 `!v region-id`
 
 ### Use region command aliases instead
+
+`&use`
+
+> @Decicus, Voice region updated to: us-east
+
+#### List of region command aliases
 
 ```
 &use => us-east

--- a/config.sample.js
+++ b/config.sample.js
@@ -1,6 +1,16 @@
 const config = {
     Discord: {
         /**
+         * This will allow EVERYONE in the server to move the server region.
+         *
+         * Set this to `false` to keep server-moving restricted.
+         * Set this to `true` to allow EVERYONE in the server to move server regions.
+         *
+         * For public/community servers, it's recommended to leave this as `false`
+         */
+        allowEveryoneToMoveRegion: false,
+
+        /**
          * Add your Discord bot token here.
          */
         token: 'REPLACE_WITH_DISCORD_BOT_TOKEN',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-server-change",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-server-change",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Allows changing Discord voice regions for a server using chat commands",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add configuration option that's **disabled by default** to allow everyone to move server regions.  
Useful for private servers, but it's recommended to keep it as `false` for public servers.

Fixes #1 